### PR TITLE
add a feature that automaticaly start hadoop cluster service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,8 @@ services:
       - '8042:8042'
       - '9870:9870'
       - '19888:19888'
+    command:
+      - /opt/start-hadoop.sh
   spark-worker-1:
     image: s1mplecc/spark-hadoop:3
     hostname: worker1


### PR DESCRIPTION
在 docker-compose.yml 文件新增了 command，可以在容器启动时自动执行 /opt/start-hadoop.sh 开启 Hadoop 集群的服务